### PR TITLE
Auto-fix: disallow Cloudflare helper routes in robots

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -9,7 +9,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: '*',
       allow: ['/', '/zh', ...TOOL_SLUGS.flatMap((slug) => [`/${slug}`, `/zh/${slug}`]), ...bboxPaths],
-      disallow: ['/api/'],
+      disallow: ['/api/', '/cdn-cgi/'],
     },
     sitemap: `${SITE_URL}/sitemap.xml`,
   };

--- a/tests/base64-geojson.test.mjs
+++ b/tests/base64-geojson.test.mjs
@@ -200,6 +200,7 @@ test('generated sitemap and robots include ordinary tool canonical routes', () =
   }
 
   assert.ok(robots.rules.disallow.includes('/api/'), 'robots should keep API routes disallowed');
+  assert.ok(robots.rules.disallow.includes('/cdn-cgi/'), 'robots should disallow Cloudflare edge helper routes');
 });
 
 test('localized base64, json-format, and geojson pages reject unsupported languages', async () => {


### PR DESCRIPTION
## Summary
- Automatically fixes robots.txt generation to disallow Cloudflare /cdn-cgi/ helper routes.
- Adds a regression assertion so the generated robots config keeps /cdn-cgi/ excluded.

## Verification
- pnpm test

## Auto-fix Mark
This PR is marked as an automatic fix for the Search Console /cdn-cgi/ crawl-noise issue.