### PR TITLE
Add feedback links and footer location

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,9 @@ See the privacy page at `/privacy` or `/zh/privacy`.
 
 Contributions are welcome. Please keep routing, metadata, sitemap, robots, and shared tool content in sync when changing public pages.
 
+- Tool ideas and general feedback: [GitHub Discussion #7](https://github.com/zmofei/mofei-dev-tools/discussions/7)
+- Bugs and broken behavior: [GitHub Issues](https://github.com/zmofei/mofei-dev-tools/issues)
+
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the broader contribution workflow.
 
 ## Algorithm Declaration

--- a/README.zh.md
+++ b/README.zh.md
@@ -261,6 +261,9 @@ BBox 的语言配置比较特殊。它支持 `en`、`zh`、`de`、`es`、`fr`，
 
 欢迎贡献。修改公开页面时，请保持路由、metadata、sitemap、robots 和共享工具内容同步。
 
+- 新工具想法和一般反馈：[GitHub Discussion #7](https://github.com/zmofei/mofei-dev-tools/discussions/7)
+- Bug 和明确坏掉的问题：[GitHub Issues](https://github.com/zmofei/mofei-dev-tools/issues)
+
 更多流程见 [CONTRIBUTING.md](CONTRIBUTING.md)。
 
 ## 算法声明

--- a/src/components/Common/Foot.tsx
+++ b/src/components/Common/Foot.tsx
@@ -69,7 +69,7 @@ function Foot() {
             <span className="truncate text-sm font-semibold">Mofei Dev Tools</span>
           </Link>
           <span className="hidden h-4 w-px shrink-0 bg-white/12 sm:block" aria-hidden="true" />
-          <span className="hidden truncate text-white/46 sm:block">Made with care in Helsinki ❤️</span>
+          <span className="hidden truncate text-white/46 sm:block">Made with ❤️ in Helsinki, Finland</span>
         </div>
 
         <nav


### PR DESCRIPTION
## Summary
- Add GitHub Discussion #7 as the tool ideas and general feedback entry in English and Chinese READMEs.
- Add GitHub Issues as the bug/broken behavior entry in both READMEs.
- Update footer signature to `Made with ❤️ in Helsinki, Finland`.

## Verification
- `git diff --check`
- `pnpm test` pass: 31/31
